### PR TITLE
Set default value of PhoneNumberUtil::$instance

### DIFF
--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -113,7 +113,7 @@ class PhoneNumberUtil
     + ['*' => '*', '#' => '#'];
 
 
-    protected static ?PhoneNumberUtil $instance;
+    protected static ?PhoneNumberUtil $instance = null;
 
     /**
      * Only upper-case variants of alpha characters are stored.


### PR DESCRIPTION
Fixes error "Typed static property libphonenumber\PhoneNumberUtil::$instance must not be accessed before initialization"

Error shows when calling `PhoneNumberUtil::getInstance()`.
Tests don't catch this error because they call `PhoneNumberUtil::resetInstance()` before calling `getInstance()` and it sets property `$instance` to `null`.
https://github.com/giggsey/libphonenumber-for-php-lite/blob/4b596681ff9a10685e1405e134e6ea080ec8cdc6/tests/core/PhoneNumberUtilTest.php#L141