### PR TITLE
Upstream metadata changes from Google for v8.13.9

### DIFF
--- a/METADATA-VERSION.txt
+++ b/METADATA-VERSION.txt
@@ -2,4 +2,4 @@
 # It can be a commit, branch or tag of the https://github.com/google/libphonenumber project
 #
 # For more information, look at the phing tasks in build.xml
-v8.13.8
+v8.13.9

--- a/src/CountryCodeToRegionCodeMap.php
+++ b/src/CountryCodeToRegionCodeMap.php
@@ -916,4 +916,5 @@ class CountryCodeToRegionCodeMap
      0 => 'UZ',
   ],
 ];
+
 }

--- a/src/CountryCodeToRegionCodeMapForTesting.php
+++ b/src/CountryCodeToRegionCodeMapForTesting.php
@@ -140,4 +140,5 @@ class CountryCodeToRegionCodeMapForTesting
      0 => 'UZ',
   ],
 ];
+
 }

--- a/src/data/PhoneNumberMetadata_BL.php
+++ b/src/data/PhoneNumberMetadata_BL.php
@@ -53,7 +53,7 @@ return [
   ],
   'voip' =>
   [
-    'NationalNumberPattern' => '9(?:395|76[018])\\d{5}',
+    'NationalNumberPattern' => '9(?:(?:395|76[018])\\d|475[01])\\d{4}',
     'ExampleNumber' => '976012345',
   ],
   'pager' =>

--- a/src/data/PhoneNumberMetadata_GF.php
+++ b/src/data/PhoneNumberMetadata_GF.php
@@ -53,7 +53,7 @@ return [
   ],
   'voip' =>
   [
-    'NationalNumberPattern' => '9(?:396|76\\d)\\d{5}',
+    'NationalNumberPattern' => '9(?:(?:396|76\\d)\\d|476[01])\\d{4}',
     'ExampleNumber' => '976012345',
   ],
   'pager' =>
@@ -98,7 +98,7 @@ return [
       'format' => '$1 $2 $3 $4',
       'leadingDigitsPatterns' =>
       [
-        0 => '[56]|97',
+        0 => '[56]|9[47]',
       ],
       'nationalPrefixFormattingRule' => '0$1',
       'domesticCarrierCodeFormattingRule' => '',

--- a/src/data/PhoneNumberMetadata_GI.php
+++ b/src/data/PhoneNumberMetadata_GI.php
@@ -9,7 +9,7 @@
 return [
   'generalDesc' =>
   [
-    'NationalNumberPattern' => '(?:[25]\\d\\d|606)\\d{5}',
+    'NationalNumberPattern' => '(?:[25]\\d|60)\\d{6}',
     'PossibleLength' =>
     [
       0 => 8,
@@ -17,12 +17,12 @@ return [
   ],
   'fixedLine' =>
   [
-    'NationalNumberPattern' => '2190[0-2]\\d{3}|2(?:0(?:0\\d|20)|16[24-9]|2[2-5]\\d)\\d{4}',
+    'NationalNumberPattern' => '2190[0-2]\\d{3}|2(?:0(?:[02]\\d|3[01])|16[24-9]|2[2-5]\\d)\\d{4}',
     'ExampleNumber' => '20012345',
   ],
   'mobile' =>
   [
-    'NationalNumberPattern' => '525(?:0\\d|1[0-4])\\d{3}|(?:5[146-8]\\d|606)\\d{5}',
+    'NationalNumberPattern' => '5251[0-4]\\d{3}|(?:5(?:[146-8]\\d\\d|250)|60(?:1[01]|6\\d))\\d{4}',
     'ExampleNumber' => '57123456',
   ],
   'tollFree' =>

--- a/src/data/PhoneNumberMetadata_GP.php
+++ b/src/data/PhoneNumberMetadata_GP.php
@@ -17,7 +17,7 @@ return [
   ],
   'fixedLine' =>
   [
-    'NationalNumberPattern' => '590(?:0[1-68]|[14][0-24-9]|2[0-68]|3[1289]|5[3-579]|6[0-489]|7[08]|8[0-689]|9\\d)\\d{4}',
+    'NationalNumberPattern' => '590(?:0[1-68]|[14][0-24-9]|2[0-68]|3[1289]|5[3-579]|[68][0-689]|7[08]|9\\d)\\d{4}',
     'ExampleNumber' => '590201234',
   ],
   'mobile' =>
@@ -53,7 +53,7 @@ return [
   ],
   'voip' =>
   [
-    'NationalNumberPattern' => '9(?:395|76[018])\\d{5}',
+    'NationalNumberPattern' => '9(?:(?:395|76[018])\\d|475[01])\\d{4}',
     'ExampleNumber' => '976012345',
   ],
   'pager' =>

--- a/src/data/PhoneNumberMetadata_HR.php
+++ b/src/data/PhoneNumberMetadata_HR.php
@@ -35,7 +35,7 @@ return [
   ],
   'mobile' =>
   [
-    'NationalNumberPattern' => '98\\d{6,7}|975(?:1\\d|77|9[67])\\d{4}|9(?:0[1-9]|[1259]\\d|7[0679])\\d{6}',
+    'NationalNumberPattern' => '9(?:(?:0[1-9]|[12589]\\d)\\d\\d|7(?:[0679]\\d\\d|5(?:[01]\\d|44|77|9[67])))\\d{4}|98\\d{6}',
     'ExampleNumber' => '921234567',
     'PossibleLength' =>
     [

--- a/src/data/PhoneNumberMetadata_MF.php
+++ b/src/data/PhoneNumberMetadata_MF.php
@@ -53,7 +53,7 @@ return [
   ],
   'voip' =>
   [
-    'NationalNumberPattern' => '9(?:395|76[018])\\d{5}',
+    'NationalNumberPattern' => '9(?:(?:395|76[018])\\d|475[01])\\d{4}',
     'ExampleNumber' => '976012345',
   ],
   'pager' =>

--- a/src/data/PhoneNumberMetadata_MQ.php
+++ b/src/data/PhoneNumberMetadata_MQ.php
@@ -53,7 +53,7 @@ return [
   ],
   'voip' =>
   [
-    'NationalNumberPattern' => '9(?:(?:39|47)7[01]|76(?:6\\d|7[0-367]))\\d{4}',
+    'NationalNumberPattern' => '9(?:397[01]|477[0-2]|76(?:6\\d|7[0-367]))\\d{4}',
     'ExampleNumber' => '976612345',
   ],
   'pager' =>


### PR DESCRIPTION
 - Updated phone metadata for region code(s): BL, GF, GI, GP, HR, MF, MQ