### PR TITLE
Add package conflicting back with giggsey/libphonenunber-for-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
     "symfony/console": "^6.0"
   },
   "conflict": {
-    "giggsey/libphonenumber-for-php": "<8.13.35"
+    "giggsey/libphonenumber-for-php": "*"
   },
   "suggest": {
     "giggsey/libphonenumber-for-php": "Use libphonenumber-for-php for geocoding, carriers, timezones and matching"

--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,9 @@
     "phpunit/phpunit": "^9.5.26",
     "symfony/console": "^6.0"
   },
+  "conflict": {
+    "giggsey/libphonenumber-for-php": "<8.13.35"
+  },
   "suggest": {
     "giggsey/libphonenumber-for-php": "Use libphonenumber-for-php for geocoding, carriers, timezones and matching"
   },


### PR DESCRIPTION
Any giggsey/libphonenumber-for-php version above 8.13.35 will replace giggsey/libphonenumber-for-php-lite. But older versions won't, so we need to implicitly conflict with them.

See #53