### PR TITLE
Ignore METADATA-VERSION.php for exporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@ tests/ export-ignore
 build.xml export-ignore
 phpunit.xml.dist export-ignore
 infection.json.dist export-ignore
+METADATA-VERSION.php export-ignore
 .github/ export-ignore
 src/CountryCodeToRegionCodeMapForTesting.php export-ignore
 

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
       "build.xml",
       "phpunit.xml.dist",
       "infection.json.dist",
+      "METADATA-VERSION.php",
       "src/CountryCodeToRegionCodeMapForTesting.php"
     ]
   },


### PR DESCRIPTION
The file `METADATA-VERSION.php` is only used during build time, and it's referenced in `build.xml`, which itself is ignored during export, so we can exclude this, too.