### PR TITLE
Upstream metadata changes from Google for v9.0.33

### DIFF
--- a/METADATA-VERSION.php
+++ b/METADATA-VERSION.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
  * For more information, look at the phing tasks in build.xml
  * @internal
  */
-return 'v9.0.32';
+return 'v9.0.33';

--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -1117,13 +1117,17 @@ class PhoneNumberUtil
     public function format(PhoneNumber $number, PhoneNumberFormat $numberFormat): string
     {
         if ($number->getNationalNumber() === '0' && $number->hasRawInput()) {
-            // Unparseable numbers that kept their raw input just use that.
-            // This is the only case where a number can be formatted as E164 without a
-            // leading '+' symbol (but the original number wasn't parseable anyway).
-            // TODO: Consider removing the 'if' above so that unparseable
-            // strings without raw input format to the empty string instead of "+00"
+            // Unparseable numbers that kept their raw input just use that, unless default country was
+            // specified and the format is E164. In that case, we prepend the raw input with the country
+            // code
             $rawInput = $number->getRawInput();
-            if ($rawInput !== '') {
+
+            if ($rawInput !== '' && $number->hasCountryCode() && $number->getCountryCodeSource() === CountryCodeSource::FROM_DEFAULT_COUNTRY && $numberFormat === PhoneNumberFormat::E164) {
+                $countryCallingCode = $number->getCountryCode();
+                $formattedNumber = $rawInput;
+                $this->prefixNumberWithCountryCallingCode($countryCallingCode, $numberFormat, $formattedNumber);
+                return $formattedNumber;
+            } elseif ($rawInput !== '' || !$number->hasCountryCode()) {
                 return $rawInput;
             }
         }

--- a/src/data/PhoneNumberMetadata_BF.php
+++ b/src/data/PhoneNumberMetadata_BF.php
@@ -35,7 +35,7 @@ class PhoneNumberMetadata_BF extends PhoneMetadata
             ->setExampleNumber('70123456');
         $this->premiumRate = PhoneNumberDesc::empty();
         $this->fixedLine = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('2(?:0(?:49|5[23]|6[5-7]|9[016-9])|4(?:4[569]|5[4-6]|6[5-7]|7[0179])|5(?:[34]\d|50|6[5-7]))\d{4}')
+            ->setNationalNumberPattern('2(?:0(?:49|5[23]|6[5-7]|9[016-9])|4(?:4[569]|5[4-6]|6[5-7]|7[0179])|5(?:[34]\d|50|6[5-8]))\d{4}')
             ->setExampleNumber('20491234');
         $this->numberFormat = [
             (new NumberFormat())

--- a/src/data/PhoneNumberMetadata_KE.php
+++ b/src/data/PhoneNumberMetadata_KE.php
@@ -34,7 +34,7 @@ class PhoneNumberMetadata_KE extends PhoneMetadata
             ->setNationalNumberPattern('(?:[17]\d\d|900)\d{6}|(?:2|80)0\d{6,7}|[4-6]\d{6,8}')
             ->setPossibleLength([7, 8, 9, 10]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:1(?:0[0-8]|1\d|2[014]|30|4[0-3])|7\d\d)\d{6}')
+            ->setNationalNumberPattern('(?:1(?:0[0-8]|1\d|2[014]|30|4[0-5])|7\d\d)\d{6}')
             ->setExampleNumber('712123456')
             ->setPossibleLength([9]);
         $this->premiumRate = (new PhoneNumberDesc())

--- a/src/data/PhoneNumberMetadata_MC.php
+++ b/src/data/PhoneNumberMetadata_MC.php
@@ -33,7 +33,7 @@ class PhoneNumberMetadata_MC extends PhoneMetadata
             ->setNationalNumberPattern('(?:[3489]|[67]\d)\d{7}')
             ->setPossibleLength([8, 9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('4(?:[469]\d|5[1-9])\d{5}|(?:3|[67]\d)\d{7}')
+            ->setNationalNumberPattern('4(?:[46]\d|5[1-9])\d{5}|(?:3|[67]\d)\d{7}')
             ->setExampleNumber('612345678');
         $this->premiumRate = PhoneNumberDesc::empty();
         $this->fixedLine = (new PhoneNumberDesc())

--- a/src/data/PhoneNumberMetadata_MW.php
+++ b/src/data/PhoneNumberMetadata_MW.php
@@ -33,13 +33,14 @@ class PhoneNumberMetadata_MW extends PhoneMetadata
             ->setNationalNumberPattern('(?:[1289]\d|31|77)\d{7}|1\d{6}')
             ->setPossibleLength([7, 9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('111\d{6}|(?:31|77|[89][89])\d{7}')
+            ->setNationalNumberPattern('111\d{6}|(?:2[12]|31|77|[89][89])\d{7}')
             ->setExampleNumber('991234567')
             ->setPossibleLength([9]);
         $this->premiumRate = PhoneNumberDesc::empty();
         $this->fixedLine = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:1[2-9]|2[12]\d\d)\d{5}')
-            ->setExampleNumber('1234567');
+            ->setNationalNumberPattern('1[2-9]\d{5}')
+            ->setExampleNumber('1234567')
+            ->setPossibleLength([7]);
         $this->numberFormat = [
             (new NumberFormat())
                 ->setPattern('(\d)(\d{3})(\d{3})')
@@ -48,15 +49,9 @@ class PhoneNumberMetadata_MW extends PhoneMetadata
                 ->setNationalPrefixFormattingRule('0$1')
                 ->setNationalPrefixOptionalWhenFormatting(false),
             (new NumberFormat())
-                ->setPattern('(\d{3})(\d{3})(\d{3})')
-                ->setFormat('$1 $2 $3')
-                ->setLeadingDigitsPattern(['2'])
-                ->setNationalPrefixFormattingRule('0$1')
-                ->setNationalPrefixOptionalWhenFormatting(false),
-            (new NumberFormat())
                 ->setPattern('(\d{3})(\d{2})(\d{2})(\d{2})')
                 ->setFormat('$1 $2 $3 $4')
-                ->setLeadingDigitsPattern(['[137-9]'])
+                ->setLeadingDigitsPattern(['[1-37-9]'])
                 ->setNationalPrefixFormattingRule('0$1')
                 ->setNationalPrefixOptionalWhenFormatting(false),
         ];

--- a/src/data/PhoneNumberMetadata_NO.php
+++ b/src/data/PhoneNumberMetadata_NO.php
@@ -42,7 +42,7 @@ class PhoneNumberMetadata_NO extends PhoneMetadata
             ->setExampleNumber('82012345')
             ->setPossibleLength([8]);
         $this->fixedLine = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:2[1-4]|3[1-3578]|5[1-35-7]|6[1-4679]|7[0-8])\d{6}')
+            ->setNationalNumberPattern('(?:2[1-4]|3[1-3578]|5[1-35-7]|6[1-46-9]|7[0-8])\d{6}')
             ->setExampleNumber('21234567')
             ->setPossibleLength([8]);
         $this->numberFormat = [

--- a/src/data/PhoneNumberMetadata_SG.php
+++ b/src/data/PhoneNumberMetadata_SG.php
@@ -32,7 +32,7 @@ class PhoneNumberMetadata_SG extends PhoneMetadata
             ->setNationalNumberPattern('(?:(?:1\d|8)\d\d|7000)\d{7}|[3689]\d{7}')
             ->setPossibleLength([8, 10, 11]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('898[02-9]\d{4}|(?:8(?:0[1-9]|[1-8]\d|9[0-79])|9[0-8]\d)\d{5}')
+            ->setNationalNumberPattern('80[1-9]\d{5}|(?:8[1-9]|9[0-8])\d{6}')
             ->setExampleNumber('81234567')
             ->setPossibleLength([8]);
         $this->premiumRate = (new PhoneNumberDesc())

--- a/src/data/PhoneNumberMetadata_SI.php
+++ b/src/data/PhoneNumberMetadata_SI.php
@@ -35,7 +35,7 @@ class PhoneNumberMetadata_SI extends PhoneMetadata
             ->setNationalNumberPattern('[1-7]\d{7}|8\d{4,7}|90\d{4,6}')
             ->setPossibleLength([5, 6, 7, 8]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('65(?:[178]\d|5[56]|6[01])\d{4}|(?:[37][01]|4[0139]|51|6[489])\d{6}')
+            ->setNationalNumberPattern('65(?:[178]\d|5[56]|6[01])\d{4}|(?:[37][01]|4[013]|51|6[489])\d{6}')
             ->setExampleNumber('31234567')
             ->setPossibleLength([8]);
         $this->premiumRate = (new PhoneNumberDesc())
@@ -62,7 +62,7 @@ class PhoneNumberMetadata_SI extends PhoneMetadata
             (new NumberFormat())
                 ->setPattern('(\d{2})(\d{3})(\d{3})')
                 ->setFormat('$1 $2 $3')
-                ->setLeadingDigitsPattern(['[37][01]|4[0139]|51|6'])
+                ->setLeadingDigitsPattern(['[37][01]|4[013]|51|6'])
                 ->setNationalPrefixFormattingRule('0$1')
                 ->setNationalPrefixOptionalWhenFormatting(false),
             (new NumberFormat())

--- a/src/data/PhoneNumberMetadata_UG.php
+++ b/src/data/PhoneNumberMetadata_UG.php
@@ -34,7 +34,7 @@ class PhoneNumberMetadata_UG extends PhoneMetadata
             ->setPossibleLengthLocalOnly([5, 6, 7])
             ->setPossibleLength([9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('72[48]0\d{5}|7(?:[014-8]\d|2[0167]|3[016]|9[0-589])\d{6}')
+            ->setNationalNumberPattern('7280\d{5}|7(?:[014-8]\d|2[01467]|3[016]|9[0-589])\d{6}')
             ->setExampleNumber('712345678');
         $this->premiumRate = (new PhoneNumberDesc())
             ->setNationalNumberPattern('90[1-3]\d{6}')

--- a/src/data/PhoneNumberMetadata_VN.php
+++ b/src/data/PhoneNumberMetadata_VN.php
@@ -30,7 +30,7 @@ class PhoneNumberMetadata_VN extends PhoneMetadata
     public function __construct()
     {
         $this->generalDesc = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('[12]\d{9}|[135-9]\d{8}|[16]\d{7}|[16-8]\d{6}')
+            ->setNationalNumberPattern('[12]\d{9}|[135-9]\d{8}|[16]\d{6,7}|7\d{6}')
             ->setPossibleLength([7, 8, 9, 10]);
         $this->mobile = (new PhoneNumberDesc())
             ->setNationalNumberPattern('121[0-3]\d{5}|(?:160|(?:3\d|7[06-9])\d|5(?:[1689]\d|2[238]|59)|8(?:[1-8]\d|9[6-9])|9(?:[0-8]\d|9[013-9]))\d{6}')
@@ -49,12 +49,6 @@ class PhoneNumberMetadata_VN extends PhoneMetadata
                 ->setPattern('(\d{3})(\d{4})')
                 ->setFormat('$1 $2')
                 ->setLeadingDigitsPattern(['[17]99'])
-                ->setNationalPrefixFormattingRule('0$1')
-                ->setNationalPrefixOptionalWhenFormatting(true),
-            (new NumberFormat())
-                ->setPattern('(\d{2})(\d{5})')
-                ->setFormat('$1 $2')
-                ->setLeadingDigitsPattern(['80'])
                 ->setNationalPrefixFormattingRule('0$1')
                 ->setNationalPrefixOptionalWhenFormatting(true),
             (new NumberFormat())
@@ -105,7 +99,7 @@ class PhoneNumberMetadata_VN extends PhoneMetadata
             ->setPossibleLength([9]);
         $this->pager = PhoneNumberDesc::empty();
         $this->uan = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:[17]99|80\d)\d{4}|69\d{5,6}')
+            ->setNationalNumberPattern('[17]99\d{4}|69\d{5,6}')
             ->setExampleNumber('1992000')
             ->setPossibleLength([7, 8]);
         $this->voicemail = PhoneNumberDesc::empty();
@@ -113,12 +107,6 @@ class PhoneNumberMetadata_VN extends PhoneMetadata
             ->setNationalNumberPattern('[17]99\d{4}|69\d{5,6}')
             ->setPossibleLength([7, 8]);
         $this->intlNumberFormat = [
-            (new NumberFormat())
-                ->setPattern('(\d{2})(\d{5})')
-                ->setFormat('$1 $2')
-                ->setLeadingDigitsPattern(['80'])
-                ->setNationalPrefixFormattingRule('0$1')
-                ->setNationalPrefixOptionalWhenFormatting(true),
             (new NumberFormat())
                 ->setPattern('(\d{4})(\d{4,6})')
                 ->setFormat('$1 $2')

--- a/tests/core/PhoneNumberUtilTest.php
+++ b/tests/core/PhoneNumberUtilTest.php
@@ -586,6 +586,16 @@ class PhoneNumberUtilTest extends TestCase
         self::assertEquals('0', $this->phoneUtil->format(self::$usSpoof, PhoneNumberFormat::NATIONAL));
     }
 
+    public function testFormatAUShortCodeNumber(): void
+    {
+        $auShortCodeNumber = $this->phoneUtil->parse('000', RegionCode::AU);
+
+        self::assertEquals('+61000', $this->phoneUtil->format($auShortCodeNumber, PhoneNumberFormat::E164));
+
+        $pgShortCodeNumber = (new PhoneNumber())->setCountryCode(675)->setNationalNumber('0')->setRawInput('+675000');
+        self::assertEquals('+675000', $this->phoneUtil->format($pgShortCodeNumber, PhoneNumberFormat::E164));
+    }
+
     public function testFormatBSNumber(): void
     {
         self::assertEquals('242 365 1234', $this->phoneUtil->format(self::$bsNumber, PhoneNumberFormat::NATIONAL));


### PR DESCRIPTION
 - Updated phone metadata for region code(s):
   BF, KE, MC, MW, NO, SG, SI, UG, VN
