### PR TITLE
Upstream metadata changes from Google for v9.0.35

### DIFF
--- a/METADATA-VERSION.php
+++ b/METADATA-VERSION.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
  * For more information, look at the phing tasks in build.xml
  * @internal
  */
-return 'v9.0.34';
+return 'v9.0.35';

--- a/src/data/PhoneNumberMetadata_AC.php
+++ b/src/data/PhoneNumberMetadata_AC.php
@@ -27,15 +27,15 @@ class PhoneNumberMetadata_AC extends PhoneMetadata
     public function __construct()
     {
         $this->generalDesc = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:[01589]\d|[46])\d{4}')
+            ->setNationalNumberPattern('(?:[01589]\d|[2-467])\d{4}')
             ->setPossibleLength([5, 6]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('4\d{4}')
+            ->setNationalNumberPattern('[2-47]\d{4}')
             ->setExampleNumber('40123')
             ->setPossibleLength([5]);
         $this->premiumRate = PhoneNumberDesc::empty();
         $this->fixedLine = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('6[2-467]\d{3}')
+            ->setNationalNumberPattern('6\d{4}')
             ->setExampleNumber('62889')
             ->setPossibleLength([5]);
         $this->tollFree = PhoneNumberDesc::empty();

--- a/src/data/PhoneNumberMetadata_CN.php
+++ b/src/data/PhoneNumberMetadata_CN.php
@@ -35,7 +35,7 @@ class PhoneNumberMetadata_CN extends PhoneMetadata
             ->setPossibleLengthLocalOnly([5, 6])
             ->setPossibleLength([7, 8, 9, 10, 11, 12]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('1740[0-5]\d{6}|1(?:[38]\d|4[57]|[59][0-35-9]|6[25-7]|7[0-35-8])\d{8}')
+            ->setNationalNumberPattern('1(?:610\d|740[0-5])\d{6}|1(?:[38]\d|4[57]|[59][0-35-9]|6[25-7]|7[0-35-8])\d{8}')
             ->setExampleNumber('13123456789')
             ->setPossibleLength([11]);
         $this->premiumRate = (new PhoneNumberDesc())

--- a/src/data/PhoneNumberMetadata_FO.php
+++ b/src/data/PhoneNumberMetadata_FO.php
@@ -32,7 +32,7 @@ class PhoneNumberMetadata_FO extends PhoneMetadata
             ->setNationalNumberPattern('[2-9]\d{5}')
             ->setPossibleLength([6]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:[27][1-9]|5\d|9[16])\d{4}')
+            ->setNationalNumberPattern('(?:[27][1-9]|5\d|9[136])\d{4}')
             ->setExampleNumber('211234');
         $this->premiumRate = (new PhoneNumberDesc())
             ->setNationalNumberPattern('90(?:[13-5][15-7]|2[125-7]|9\d)\d\d')

--- a/src/data/PhoneNumberMetadata_GE.php
+++ b/src/data/PhoneNumberMetadata_GE.php
@@ -35,7 +35,7 @@ class PhoneNumberMetadata_GE extends PhoneMetadata
             ->setPossibleLengthLocalOnly([6, 7])
             ->setPossibleLength([9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('5(?:(?:(?:0555|1(?:[17]77|555))[5-9]|757(?:7[7-9]|8[01]))\d|22252[0-4])\d\d|5(?:0(?:0(?:1[09]|70)|505)|1(?:0[01]0|1(?:07|33|51))|2(?:0[02]0|2[25]2)|3(?:0[03]0|3[35]3)|(?:40[04]|900)0|5222)[0-4]\d{3}|(?:5(?:0(?:0(?:0\d|1[12]|22|3[0-6]|44|5[05]|77|88|9[09])|(?:[14]\d|77)\d|22[02])|1(?:1(?:[03][01]|[124]\d|5[2-6]|7[0-6])|4\d\d)|[23]555|4(?:4\d\d|555)|5(?:[0157-9]\d\d|200|333|4(?:44|55))|6[89]\d\d|7(?:(?:[0147-9]\d|22)\d|5(?:00|[57]5))|8(?:0(?:[018]\d|2[0-4])|5(?:55|8[89])|8(?:55|88))|9(?:090|[1-35-9]\d\d))|790\d\d)\d{4}')
+            ->setNationalNumberPattern('5(?:(?:(?:0555|1(?:[17]77|555))[5-9]|757(?:7[7-9]|8[01]))\d|22252[0-4])\d\d|5(?:0(?:0(?:1[09]|70)|505)|1(?:0[01]0|1(?:07|33|51))|2(?:0[02]0|2[25]2)|3(?:0[03]0|3[35]3)|(?:40[04]|900)0|5222)[0-4]\d{3}|(?:5(?:0(?:0(?:0\d|1[12]|22|3[0-6]|44|5[05]|77|88|9[09])|(?:[14]\d|77)\d|22[02])|1(?:1(?:[03][01]|[124]\d|5[2-6]|7[0-6])|4\d\d)|2(?:228|555)|3555|4(?:4\d\d|555)|5(?:[0157-9]\d\d|200|333|4(?:44|55))|6[89]\d\d|7(?:(?:[0147-9]\d|22)\d|5(?:00|[57]5))|8(?:0(?:[018]\d|2[0-4])|5(?:55|8[89])|8(?:55|88))|9(?:090|[1-35-9]\d\d))|790\d\d)\d{4}')
             ->setExampleNumber('555123456');
         $this->premiumRate = PhoneNumberDesc::empty();
         $this->fixedLine = (new PhoneNumberDesc())
@@ -58,12 +58,12 @@ class PhoneNumberMetadata_GE extends PhoneMetadata
             (new NumberFormat())
                 ->setPattern('(\d{3})(\d{2})(\d{2})(\d{2})')
                 ->setFormat('$1 $2 $3 $4')
-                ->setLeadingDigitsPattern(['[57]'])
+                ->setLeadingDigitsPattern(['5(?:[0-46-9]|5[0-57-9])|7', '5(?:[0-46-9]|5(?:[0-357-9]|44))|7'])
                 ->setNationalPrefixOptionalWhenFormatting(false),
             (new NumberFormat())
                 ->setPattern('(\d{3})(\d{2})(\d{2})(\d{2})')
                 ->setFormat('$1 $2 $3 $4')
-                ->setLeadingDigitsPattern(['[348]'])
+                ->setLeadingDigitsPattern(['[3-58]'])
                 ->setNationalPrefixFormattingRule('0$1')
                 ->setNationalPrefixOptionalWhenFormatting(false),
         ];

--- a/src/data/PhoneNumberMetadata_IR.php
+++ b/src/data/PhoneNumberMetadata_IR.php
@@ -35,7 +35,7 @@ class PhoneNumberMetadata_IR extends PhoneMetadata
             ->setPossibleLengthLocalOnly([8])
             ->setPossibleLength([4, 5, 6, 7, 10]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('9(?:(?:0[0-5]|[13]\d|2[0-3])\d\d|9(?:[0-46]\d\d|5(?:10|5\d)|8(?:[12]\d|88)|9(?:[01359]\d|21|69|77|8[7-9])))\d{5}')
+            ->setNationalNumberPattern('9(?:(?:0[0-5]|[13]\d|2[0-3])\d\d|9(?:[0-46]\d\d|5(?:10|5\d)|8(?:[12]\d|3[0-2]|88)|9(?:[01359]\d|21|69|77|8[7-9])))\d{5}')
             ->setExampleNumber('9123456789')
             ->setPossibleLength([10]);
         $this->premiumRate = PhoneNumberDesc::empty();

--- a/src/data/PhoneNumberMetadata_KE.php
+++ b/src/data/PhoneNumberMetadata_KE.php
@@ -34,7 +34,7 @@ class PhoneNumberMetadata_KE extends PhoneMetadata
             ->setNationalNumberPattern('(?:[17]\d\d|900)\d{6}|(?:2|80)0\d{6,7}|[4-6]\d{6,8}')
             ->setPossibleLength([7, 8, 9, 10]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:1(?:0[0-8]|1\d|2[014]|30|4[0-5])|7\d\d)\d{6}')
+            ->setNationalNumberPattern('(?:1(?:0[0-8]|[18]\d|2[014]|30|4[0-5])|7\d\d)\d{6}')
             ->setExampleNumber('712123456')
             ->setPossibleLength([9]);
         $this->premiumRate = (new PhoneNumberDesc())

--- a/src/data/PhoneNumberMetadata_SE.php
+++ b/src/data/PhoneNumberMetadata_SE.php
@@ -34,7 +34,7 @@ class PhoneNumberMetadata_SE extends PhoneMetadata
             ->setNationalNumberPattern('(?:[26]\d\d|9)\d{9}|[1-9]\d{8}|[1-689]\d{7}|[1-4689]\d{6}|2\d{5}')
             ->setPossibleLength([6, 7, 8, 9, 10, 12]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('7[02369]\d{7}')
+            ->setNationalNumberPattern('7[023689]\d{7}')
             ->setExampleNumber('701234567')
             ->setPossibleLength([9]);
         $this->premiumRate = (new PhoneNumberDesc())

--- a/src/data/PhoneNumberMetadata_UG.php
+++ b/src/data/PhoneNumberMetadata_UG.php
@@ -34,7 +34,7 @@ class PhoneNumberMetadata_UG extends PhoneMetadata
             ->setPossibleLengthLocalOnly([5, 6, 7])
             ->setPossibleLength([9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('7280\d{5}|7(?:[014-8]\d|2[01467]|3[016]|9[0-589])\d{6}')
+            ->setNationalNumberPattern('7280\d{5}|7(?:[014-8]\d|2[01467]|3[0167]|9[0-589])\d{6}')
             ->setExampleNumber('712345678');
         $this->premiumRate = (new PhoneNumberDesc())
             ->setNationalNumberPattern('90[1-3]\d{6}')

--- a/src/data/PhoneNumberMetadata_ZW.php
+++ b/src/data/PhoneNumberMetadata_ZW.php
@@ -34,7 +34,7 @@ class PhoneNumberMetadata_ZW extends PhoneMetadata
             ->setPossibleLengthLocalOnly([3, 4])
             ->setPossibleLength([5, 6, 7, 8, 9, 10]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('7(?:[1278]\d|3[1-9])\d{6}')
+            ->setNationalNumberPattern('7(?:[1278]\d|3[1-9]|9[01])\d{6}')
             ->setExampleNumber('712345678')
             ->setPossibleLength([9]);
         $this->premiumRate = PhoneNumberDesc::empty();

--- a/src/data/ShortNumberMetadata_FR.php
+++ b/src/data/ShortNumberMetadata_FR.php
@@ -41,7 +41,7 @@ class ShortNumberMetadata_FR extends PhoneMetadata
             ->setExampleNumber('15')
             ->setPossibleLength([2, 3]);
         $this->short_code = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('1(?:0\d\d|1(?:[02459]|6(?:000|111)|8\d{3})|[578]|9[167])|2(?:0(?:00|2)0|24)|[3-8]\d{4}|3\d{3}|6(?:1[14]|34)|7(?:0[06]|22|40)')
+            ->setNationalNumberPattern('1(?:0\d\d|1(?:[02459]|6(?:00[06]|11[17])|8\d{3})|[578]|9[167])|2(?:0(?:00|2)0|24)|[3-8]\d{4}|3\d{3}|6(?:1[14]|34)|7(?:0[06]|22|40)')
             ->setExampleNumber('15');
         $this->standard_rate = (new PhoneNumberDesc())
             ->setNationalNumberPattern('202\d|6(?:1[14]|34)|70[06]')


### PR DESCRIPTION
 - Updated phone metadata for region code(s): AC, CN, FO, GE, IR, KE, SE, UG, ZW