### PR TITLE
Upstream changes from Google for v9.0.36

### DIFF
--- a/METADATA-VERSION.php
+++ b/METADATA-VERSION.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
  * For more information, look at the phing tasks in build.xml
  * @internal
  */
-return 'v9.0.35';
+return 'v9.0.36';

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -381,7 +381,7 @@ class PhoneNumber implements Serializable
     }
 
     /**
-     * @param array{int,string,string,bool|null,int,string|null,CountryCodeSource|null,string|null} $data
+     * @param array{int,string,string,bool|null,int,string|null,CountryCodeSource|int|null,string|null} $data
      */
     public function __unserialize(array $data): void
     {

--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -1334,6 +1334,30 @@ class PhoneNumberUtil
     }
 
     /**
+     * Checks whether the supplied string contains at least three ASCII letters.
+     */
+    private function hasAtLeastThreeAlphaChars(string $number): bool
+    {
+        $alphaCount = 0;
+        $length = strlen($number);
+
+        for ($i = 0; $i < $length; $i++) {
+            $character = ord($number[$i]);
+
+            if (
+                ($character >= 65 && $character <= 90)
+                || ($character >= 97 && $character <= 122)
+            ) {
+                if (++$alphaCount >= 3) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Checks if the number is a valid vanity (alpha) number such as 800 MICROSOFT. A valid vanity
      * number will start with at least 3 digits and will have three or more alpha characters. This
      * does not do region-specific checks - to work out if this number is actually valid for a region,
@@ -1345,12 +1369,18 @@ class PhoneNumberUtil
      */
     public function isAlphaNumber(string $number): bool
     {
-        if (!static::isViablePhoneNumber($number)) {
-            // Number is too short, or doesn't match the basic phone number pattern.
+        if (strlen($number) > static::MAX_INPUT_STRING_LENGTH) {
             return false;
         }
+
+        if (!static::isViablePhoneNumber($number)) {
+            // Number is too short, or doesn't match the basic phone-number pattern.
+            return false;
+        }
+
         $this->maybeStripExtension($number);
-        return preg_match('/' . static::VALID_ALPHA_PHONE_PATTERN . '/' . static::REGEX_FLAGS, $number) === 1;
+
+        return $this->hasAtLeastThreeAlphaChars($number);
     }
 
     /**

--- a/src/PhoneNumberUtil.php
+++ b/src/PhoneNumberUtil.php
@@ -895,9 +895,11 @@ class PhoneNumberUtil
     public function getNationalSignificantNumber(PhoneNumber $number): string
     {
         // If leading zero(s) have been set, we prefix this now. Note this is not a national prefix.
+        // Defensively cap the number of leading zeros to avoid OOM from malicious input.
         $nationalNumber = '';
         if ($number->isItalianLeadingZero() && $number->getNumberOfLeadingZeros() > 0) {
-            $zeros = str_repeat('0', $number->getNumberOfLeadingZeros());
+            $numberOfLeadingZeros = min($number->getNumberOfLeadingZeros(), 10);
+            $zeros = str_repeat('0', $numberOfLeadingZeros);
             $nationalNumber .= $zeros;
         }
         $nationalNumber .= $number->getNationalNumber();

--- a/src/data/PhoneNumberMetadata_BD.php
+++ b/src/data/PhoneNumberMetadata_BD.php
@@ -75,7 +75,7 @@ class PhoneNumberMetadata_BD extends PhoneMetadata
         $this->sharedCost = PhoneNumberDesc::empty();
         $this->personalNumber = PhoneNumberDesc::empty();
         $this->voip = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('96(?:0[469]|1[0-47]|3[389]|43|6[69]|7[78])\d{6}')
+            ->setNationalNumberPattern('96(?:0[1-69]|1[0-479]|2[278]|3[13-9]|4[013]|54|6[69]|7[78]|88)\d{6}')
             ->setExampleNumber('9604123456')
             ->setPossibleLength([10]);
         $this->pager = PhoneNumberDesc::empty();

--- a/src/data/PhoneNumberMetadata_EH.php
+++ b/src/data/PhoneNumberMetadata_EH.php
@@ -32,7 +32,7 @@ class PhoneNumberMetadata_EH extends PhoneMetadata
             ->setNationalNumberPattern('[5-8]\d{8}')
             ->setPossibleLength([9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:6(?:[0-79]\d|8[0-247-9])|7(?:[016-8]\d|2[0-8]|5[0-5]))\d{6}')
+            ->setNationalNumberPattern('(?:6(?:[0-79]\d|8[0-247-9])|7(?:[016-8]\d|2[0-8]|3[01]|5[0-5]))\d{6}')
             ->setExampleNumber('650123456');
         $this->premiumRate = (new PhoneNumberDesc())
             ->setNationalNumberPattern('89\d{7}')

--- a/src/data/PhoneNumberMetadata_FO.php
+++ b/src/data/PhoneNumberMetadata_FO.php
@@ -32,7 +32,7 @@ class PhoneNumberMetadata_FO extends PhoneMetadata
             ->setNationalNumberPattern('[2-9]\d{5}')
             ->setPossibleLength([6]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:[27][1-9]|5\d|9[136])\d{4}')
+            ->setNationalNumberPattern('(?:[27][1-9]|5\d|9[16])\d{4}')
             ->setExampleNumber('211234');
         $this->premiumRate = (new PhoneNumberDesc())
             ->setNationalNumberPattern('90(?:[13-5][15-7]|2[125-7]|9\d)\d\d')
@@ -42,8 +42,8 @@ class PhoneNumberMetadata_FO extends PhoneMetadata
             ->setExampleNumber('201234');
         $this->numberFormat = [
             (new NumberFormat())
-                ->setPattern('(\d{6})')
-                ->setFormat('$1')
+                ->setPattern('(\d{2})(\d{2})(\d{2})')
+                ->setFormat('$1 $2 $3')
                 ->setLeadingDigitsPattern(['[2-9]'])
                 ->setDomesticCarrierCodeFormattingRule('$CC $1')
                 ->setNationalPrefixOptionalWhenFormatting(false),
@@ -54,7 +54,7 @@ class PhoneNumberMetadata_FO extends PhoneMetadata
         $this->sharedCost = PhoneNumberDesc::empty();
         $this->personalNumber = PhoneNumberDesc::empty();
         $this->voip = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:6[0-36]|88)\d{4}')
+            ->setNationalNumberPattern('6[0-36]\d{4}')
             ->setExampleNumber('601234');
         $this->pager = PhoneNumberDesc::empty();
         $this->uan = PhoneNumberDesc::empty();

--- a/src/data/PhoneNumberMetadata_GE.php
+++ b/src/data/PhoneNumberMetadata_GE.php
@@ -35,7 +35,7 @@ class PhoneNumberMetadata_GE extends PhoneMetadata
             ->setPossibleLengthLocalOnly([6, 7])
             ->setPossibleLength([9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('5(?:(?:(?:0555|1(?:[17]77|555))[5-9]|757(?:7[7-9]|8[01]))\d|22252[0-4])\d\d|5(?:0(?:0(?:1[09]|70)|505)|1(?:0[01]0|1(?:07|33|51))|2(?:0[02]0|2[25]2)|3(?:0[03]0|3[35]3)|(?:40[04]|900)0|5222)[0-4]\d{3}|(?:5(?:0(?:0(?:0\d|1[12]|22|3[0-6]|44|5[05]|77|88|9[09])|(?:[14]\d|77)\d|22[02])|1(?:1(?:[03][01]|[124]\d|5[2-6]|7[0-6])|4\d\d)|2(?:228|555)|3555|4(?:4\d\d|555)|5(?:[0157-9]\d\d|200|333|4(?:44|55))|6[89]\d\d|7(?:(?:[0147-9]\d|22)\d|5(?:00|[57]5))|8(?:0(?:[018]\d|2[0-4])|5(?:55|8[89])|8(?:55|88))|9(?:090|[1-35-9]\d\d))|790\d\d)\d{4}')
+            ->setNationalNumberPattern('5(?:(?:(?:0555|1(?:[17]77|555))[5-9]|757(?:7[7-9]|8[01]))\d|22252[0-4])\d\d|5(?:0(?:0(?:1[09]|70)|505)|1(?:0[01]0|1(?:07|33|51))|2(?:0[02]0|2[25]2)|3(?:0[03]0|3[35]3)|4(?:0[04]0|411)|5222|9000)[0-4]\d{3}|(?:5(?:0(?:0(?:0\d|1[12]|2[02]|3[0-6]|4[04]|5[05]|77|88|9[09])|(?:[14]\d|77)\d|22[02])|1(?:1(?:[03][01]|[124]\d|5[02-6]|7[0-6])|4\d\d)|2(?:228|555)|3555|4(?:4(?:[02-9]\d|14)|555)|5(?:[0157-9]\d\d|200|333|4(?:44|55))|6[89]\d\d|7(?:(?:[0147-9]\d|22)\d|5(?:00|[57]5))|8(?:0(?:[018]\d|2[0-4])|5(?:55|8[89])|8(?:55|88))|9(?:090|[1-35-9]\d\d))|790\d\d)\d{4}')
             ->setExampleNumber('555123456');
         $this->premiumRate = PhoneNumberDesc::empty();
         $this->fixedLine = (new PhoneNumberDesc())
@@ -58,12 +58,12 @@ class PhoneNumberMetadata_GE extends PhoneMetadata
             (new NumberFormat())
                 ->setPattern('(\d{3})(\d{2})(\d{2})(\d{2})')
                 ->setFormat('$1 $2 $3 $4')
-                ->setLeadingDigitsPattern(['5(?:[0-46-9]|5[0-57-9])|7', '5(?:[0-46-9]|5(?:[0-357-9]|44))|7'])
+                ->setLeadingDigitsPattern(['[57]'])
                 ->setNationalPrefixOptionalWhenFormatting(false),
             (new NumberFormat())
                 ->setPattern('(\d{3})(\d{2})(\d{2})(\d{2})')
                 ->setFormat('$1 $2 $3 $4')
-                ->setLeadingDigitsPattern(['[3-58]'])
+                ->setLeadingDigitsPattern(['[348]'])
                 ->setNationalPrefixFormattingRule('0$1')
                 ->setNationalPrefixOptionalWhenFormatting(false),
         ];

--- a/src/data/PhoneNumberMetadata_IL.php
+++ b/src/data/PhoneNumberMetadata_IL.php
@@ -34,7 +34,7 @@ class PhoneNumberMetadata_IL extends PhoneMetadata
             ->setNationalNumberPattern('1\d{6}(?:\d{3,5})?|[57]\d{8}|[1-489]\d{7}')
             ->setPossibleLength([7, 8, 9, 10, 11, 12]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('55(?:4(?:0[0-3]|[16]0)|57[0-289])\d{4}|5(?:(?:[0-2][02-9]|[36]\d|[49][2-9]|8[3-7])\d|5(?:01|2\d|3[0-3]|4[3-5]|5[0-25689]|6[6-8]|7[0-267]|8[7-9]|9[1-9]))\d{5}')
+            ->setNationalNumberPattern('55(?:4(?:0[0-3]|10|6[015-9])|57[0-289]|8[06][0-2])\d{4}|5(?:(?:[0-2][02-9]|[36]\d|[49][2-9]|8[3-7])\d|5(?:01|2\d|3[0-3]|4[3-5]|5[0-25689]|6[6-8]|7[0-267]|8[7-9]|9[1-9]))\d{5}')
             ->setExampleNumber('502345678')
             ->setPossibleLength([9]);
         $this->premiumRate = (new PhoneNumberDesc())
@@ -100,7 +100,7 @@ class PhoneNumberMetadata_IL extends PhoneMetadata
             ->setPossibleLength([10]);
         $this->personalNumber = PhoneNumberDesc::empty();
         $this->voip = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('7(?:38(?:[05]\d|8[0138])|8(?:33|55|77|81)\d)\d{4}|7(?:18|2[23]|3[237]|47|6[258]|7\d|82|9[2-9])\d{6}')
+            ->setNationalNumberPattern('7(?:280[01]|38(?:[05]\d|8[01358])|8(?:33|55|77|81)\d)\d{4}|7(?:18|2[23]|3[237]|47|6[258]|7\d|82|9[2-9])\d{6}')
             ->setExampleNumber('771234567')
             ->setPossibleLength([9]);
         $this->pager = PhoneNumberDesc::empty();

--- a/src/data/PhoneNumberMetadata_LI.php
+++ b/src/data/PhoneNumberMetadata_LI.php
@@ -33,7 +33,7 @@ class PhoneNumberMetadata_LI extends PhoneMetadata
             ->setNationalNumberPattern('[68]\d{8}|(?:[2378]\d|90)\d{5}')
             ->setPossibleLength([7, 9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:6(?:(?:4[5-9]|5\d)\d|6(?:[024-68]\d|1[01]|3[7-9]|70))\d|7(?:[37-9]\d|42|56))\d{4}')
+            ->setNationalNumberPattern('(?:6(?:(?:4[5-9]|5\d)\d|6(?:[024-68]\d|1[01]|3[7-9]|7[02]))\d|7(?:[37-9]\d|42|56))\d{4}')
             ->setExampleNumber('660234567');
         $this->premiumRate = (new PhoneNumberDesc())
             ->setNationalNumberPattern('90(?:02[258]|1(?:23|3[14])|66[136])\d\d')

--- a/src/data/PhoneNumberMetadata_MA.php
+++ b/src/data/PhoneNumberMetadata_MA.php
@@ -36,7 +36,7 @@ class PhoneNumberMetadata_MA extends PhoneMetadata
             ->setNationalNumberPattern('[5-8]\d{8}')
             ->setPossibleLength([9]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('(?:6(?:[0-79]\d|8[0-247-9])|7(?:[016-8]\d|2[0-8]|5[0-5]))\d{6}')
+            ->setNationalNumberPattern('(?:6(?:[0-79]\d|8[0-247-9])|7(?:[016-8]\d|2[0-8]|3[01]|5[0-5]))\d{6}')
             ->setExampleNumber('650123456');
         $this->premiumRate = (new PhoneNumberDesc())
             ->setNationalNumberPattern('89\d{7}')

--- a/src/data/PhoneNumberMetadata_ML.php
+++ b/src/data/PhoneNumberMetadata_ML.php
@@ -35,7 +35,7 @@ class PhoneNumberMetadata_ML extends PhoneMetadata
             ->setExampleNumber('65012345');
         $this->premiumRate = PhoneNumberDesc::empty();
         $this->fixedLine = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('2(?:07[0-8]|12[67])\d{4}|(?:2(?:02|1[4-689])|4(?:0[0-4]|4[1-59]))\d{5}')
+            ->setNationalNumberPattern('2(?:07[0-8]|12[67])\d{4}|(?:2(?:02|1[4-689])|4(?:0[0-4]|4[1-69]))\d{5}')
             ->setExampleNumber('20212345');
         $this->numberFormat = [
             (new NumberFormat())

--- a/src/data/PhoneNumberMetadata_NO.php
+++ b/src/data/PhoneNumberMetadata_NO.php
@@ -34,7 +34,7 @@ class PhoneNumberMetadata_NO extends PhoneMetadata
             ->setNationalNumberPattern('(?:0|[2-9]\d{3})\d{4}')
             ->setPossibleLength([5, 8]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('[49]\d{7}')
+            ->setNationalNumberPattern('(?:4[015-9]|9\d)\d{6}')
             ->setExampleNumber('40612345')
             ->setPossibleLength([8]);
         $this->premiumRate = (new PhoneNumberDesc())

--- a/src/data/PhoneNumberMetadata_SJ.php
+++ b/src/data/PhoneNumberMetadata_SJ.php
@@ -31,7 +31,7 @@ class PhoneNumberMetadata_SJ extends PhoneMetadata
             ->setNationalNumberPattern('0\d{4}|(?:[489]\d|79)\d{6}')
             ->setPossibleLength([5, 8]);
         $this->mobile = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('[49]\d{7}')
+            ->setNationalNumberPattern('(?:4[015-9]|9\d)\d{6}')
             ->setExampleNumber('41234567')
             ->setPossibleLength([8]);
         $this->premiumRate = (new PhoneNumberDesc())

--- a/src/data/ShortNumberMetadata_FO.php
+++ b/src/data/ShortNumberMetadata_FO.php
@@ -38,10 +38,13 @@ class ShortNumberMetadata_FO extends PhoneMetadata
             ->setExampleNumber('112')
             ->setPossibleLength([3]);
         $this->short_code = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('1(?:1[248]|819)|1(?:4[124]|71|8[7-9])\d')
+            ->setNationalNumberPattern('11[248]|1(?:4[124]|71|8[17-9]|9\d)\d')
             ->setExampleNumber('112');
         $this->standard_rate = PhoneNumberDesc::empty();
         $this->carrierSpecific = PhoneNumberDesc::empty();
-        $this->smsServices = PhoneNumberDesc::empty();
+        $this->smsServices = (new PhoneNumberDesc())
+            ->setNationalNumberPattern('19\d\d')
+            ->setExampleNumber('1900')
+            ->setPossibleLength([4]);
     }
 }

--- a/src/data/ShortNumberMetadata_IT.php
+++ b/src/data/ShortNumberMetadata_IT.php
@@ -34,7 +34,7 @@ class ShortNumberMetadata_IT extends PhoneMetadata
             ->setExampleNumber('1200')
             ->setPossibleLength([4, 5, 7]);
         $this->tollFree = (new PhoneNumberDesc())
-            ->setNationalNumberPattern('1(?:1(?:[2358]|6\d{3})|87)')
+            ->setNationalNumberPattern('1(?:1(?:[2358]|6\d{3})|46|87)')
             ->setExampleNumber('112')
             ->setPossibleLength([3, 6]);
         $this->emergency = (new PhoneNumberDesc())


### PR DESCRIPTION
 - [Cap the number of leading zeros to getNationalSignificantNumber](https://github.com/giggsey/libphonenumber-for-php-lite/commit/18a4d3aa67a49d3969e97ada2b65ed28c672e20a)
 - [Replace recursive regex with linear scan in isAlphaNumber()](https://github.com/giggsey/libphonenumber-for-php-lite/commit/1b65acc9278b0449ef4676576073c5ab3d7c5566)
 - Updated phone metadata for region code(s):
   BD, EH, FO, GE, IL, LI, MA, ML, NO, SJ
 - Updated short number metadata for region code(s): FO, IT
